### PR TITLE
feat: remove authorize method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ npm i @wetransfer/js-sdk --save
 In order to be able to use the SDK and access our public APIs, you must provide an API key, which is available in our [Developers Portal](https://developers.wetransfer.com/).
 
 ```javascript
-const apiClient = require('@wetransfer/js-sdk')('/* YOUR PRIVATE API KEY GOES HERE*/');
+const createWTClient = require('@wetransfer/js-sdk');
+// An authorization call is made when you create the client.
+// Keep that in mind to perform this operation
+// in the most suitable part of your code
+const apiClient = await createWTClient('/* YOUR PRIVATE API KEY GOES HERE*/');
 
 const transfer = await apiClient.transfer.create({
   name: 'My very first transfer!'

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,0 +1,32 @@
+const nock = require('nock');
+
+const createWTClient = require('../src');
+
+describe('createWTClient function', () => {
+  beforeEach(() => {
+    nock('https://dev.wetransfer.com')
+      .post('/v1/authorize')
+      .reply(200);
+  });
+
+  it('should return a client if API KEY is provided', async () => {
+    try {
+      await createWTClient();
+    } catch ({ message }) {
+      expect(message).toEqual('No API Key provided');
+    }
+  });
+
+  it('should return an API client', async () => {
+    const apiClient = await createWTClient('super-secret-api-key');
+    expect(apiClient).toEqual({
+      authorize: expect.any(Function),
+      transfer: {
+        addItems: expect.any(Function),
+        completeFileUpload: expect.any(Function),
+        create: expect.any(Function),
+        uploadFile: expect.any(Function)
+      }
+    });
+  });
+});

--- a/__tests__/request/index.js
+++ b/__tests__/request/index.js
@@ -10,40 +10,52 @@ describe('Request module', () => {
   });
 
   afterEach(() => {
-    delete request._apiKey;
-    delete request._jwt;
+    request.apiKey = null;
+    request.jwt = null;
   });
 
   it('should set defaults', () => {
-    expect(axios.defaults).toEqual(expect.objectContaining({
-      baseURL: 'https://dev.wetransfer.com/',
-      method: 'post'
-    }));
+    expect(axios.defaults).toEqual(
+      expect.objectContaining({
+        baseURL: 'https://dev.wetransfer.com/',
+        method: 'post'
+      })
+    );
   });
 
   describe('apiKey property', () => {
-    it('should set an apiKey value', () => {
+    beforeEach(() => {
       request.apiKey = 'secret-api-key';
-      expect(request._apiKey).toBe('secret-api-key');
     });
 
-    it('should throw an error when no apiKey is provided', () => {
-      expect(() => {
-        request.apiKey = undefined;
-      }).toThrow('No API Key provided');
+    it('should set an apiKey value', async () => {
+      await request.send();
+      expect(axios).toHaveBeenLastCalledWith({
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'secret-api-key'
+        },
+        data: null
+      });
     });
   });
 
   describe('JWT property', () => {
-    it('should set an JWT value', () => {
-      request.jwt = 'json-web-token';
-      expect(request._jwt).toBe('json-web-token');
+    beforeEach(() => {
+      request.apiKey = 'secret-api-key';
     });
 
-    it('should throw an error when no jwt is provided', () => {
-      expect(() => {
-        request.jwt = undefined;
-      }).toThrow('No JWT provided');
+    it('should set an JWT value', async () => {
+      request.jwt = 'json-web-token';
+      await request.send();
+      expect(axios).toHaveBeenLastCalledWith({
+        headers: {
+          'Authorization': 'Bearer json-web-token',
+          'Content-Type': 'application/json',
+          'x-api-key': 'secret-api-key'
+        },
+        data: null
+      });
     });
   });
 
@@ -78,7 +90,7 @@ describe('Request module', () => {
 
     it('should create a request including extra options', async () => {
       request.jwt = 'json-web-token';
-      await request.send({ headers: { 'X-Extra-Header' : 'value' } });
+      await request.send({ headers: { 'X-Extra-Header': 'value' } });
       expect(axios).toHaveBeenLastCalledWith({
         headers: {
           'Authorization': 'Bearer json-web-token',
@@ -106,7 +118,10 @@ describe('Request module', () => {
 
   describe('upload method', () => {
     it('should create a PUT request', async () => {
-      await request.upload('https://dev.wetransfer.com/very-long-url', 'some-data');
+      await request.upload(
+        'https://dev.wetransfer.com/very-long-url',
+        'some-data'
+      );
       expect(axios).toHaveBeenLastCalledWith({
         data: 'some-data',
         method: 'put',

--- a/__tests__/transfer/model/index.js
+++ b/__tests__/transfer/model/index.js
@@ -1,4 +1,7 @@
-const { normalizeItem, normalizeTransfer } = require('../../../src/transfer/model');
+const {
+  normalizeItem,
+  normalizeTransfer
+} = require('../../../src/transfer/model');
 
 describe('Transfer model', () => {
   describe('normalizeItem function', () => {
@@ -39,7 +42,7 @@ describe('Transfer model', () => {
     beforeEach(() => {
       transfer = {
         name: 'WeTransfer rocks',
-        description: null
+        description: ''
       };
     });
 
@@ -58,7 +61,7 @@ describe('Transfer model', () => {
       const normalized = normalizeTransfer({});
       expect(normalized).toEqual({
         name: '',
-        description: null
+        description: ''
       });
     });
   });

--- a/src/authorize/index.js
+++ b/src/authorize/index.js
@@ -1,8 +1,6 @@
 const routes = require('../config/routes');
 const request = require('../request');
 
-module.exports = async function authorize() {
-  const auth = await request.send(routes.authorize);
-  request.jwt = auth.token;
-  return auth;
+module.exports = function authorize() {
+  return request.send(routes.authorize);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,13 @@ const authorize = require('./authorize');
 const request = require('./request');
 const transfer = require('./transfer');
 
-module.exports = function createWTClient(apiKey) {
+module.exports = async function createWTClient(apiKey) {
+  if (!apiKey) {
+    throw new Error('No API Key provided');
+  }
+
   request.apiKey = apiKey;
+  request.jwt = (await authorize()).token;
 
   return {
     authorize,

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -4,6 +4,11 @@ const { merge } = require('lodash');
 axios.defaults.baseURL = 'https://dev.wetransfer.com/';
 axios.defaults.method = 'post';
 
+const auth = {
+  apiKey: null,
+  jwt: null
+};
+
 function defaultOptions(apiKey, jwt) {
   const options = {
     headers: {
@@ -22,7 +27,7 @@ function defaultOptions(apiKey, jwt) {
 function send(options = {}, data = null) {
   const requestOptions = merge(
     {},
-    defaultOptions(this._apiKey, this._jwt),
+    defaultOptions(auth.apiKey, auth.jwt),
     options,
     { data }
   );
@@ -43,17 +48,9 @@ module.exports = {
   send,
   upload,
   set apiKey(apiKey) {
-    if (!apiKey) {
-      throw new Error('No API Key provided');
-    }
-
-    this._apiKey = apiKey;
+    auth.apiKey = apiKey;
   },
   set jwt(jwt) {
-    if (!jwt) {
-      throw new Error('No JWT provided');
-    }
-
-    this._jwt = jwt;
+    auth.jwt = jwt;
   }
 };

--- a/src/transfer/model/index.js
+++ b/src/transfer/model/index.js
@@ -2,7 +2,7 @@ const { defaults, pick } = require('lodash');
 
 const defaultTransferItem = {
   name: '',
-  description: null
+  description: ''
 };
 
 const defaultFileItem = {
@@ -19,8 +19,12 @@ const defaultFileItem = {
  * @returns {Object} Normalized transfer object
  */
 function normalizeTransfer(transfer) {
-  return defaults({}, pick(transfer, Object.keys(defaultTransferItem)), defaultTransferItem);
-};
+  return defaults(
+    {},
+    pick(transfer, Object.keys(defaultTransferItem)),
+    defaultTransferItem
+  );
+}
 
 /**
  * Normalizes an item object (file or link). Removes non-expected properties and
@@ -30,8 +34,12 @@ function normalizeTransfer(transfer) {
  */
 function normalizeItem(item) {
   // TODO: create different models for files and links
-  return defaults({}, pick(item, Object.keys(defaultFileItem)), defaultFileItem);
-};
+  return defaults(
+    {},
+    pick(item, Object.keys(defaultFileItem)),
+    defaultFileItem
+  );
+}
 
 module.exports = {
   normalizeTransfer,


### PR DESCRIPTION
## Proposed changes

Remove the need for the client to call `authorize` at the beginning of the process, and make it part of the client initialization.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules
