### PR TITLE
Add async keyword

### DIFF
--- a/src/transfer/items.js
+++ b/src/transfer/items.js
@@ -64,7 +64,7 @@ function getChunkSizes(totalSize) {
  * @param   {Array}   items      A collection of items to be added to the transfer
  * @returns {Promise}            A collection of created items
  */
-function addItems(transferId, items) {
+async function addItems(transferId, items) {
   return request.send(routes.items(transferId), {
     items: items.map(normalizeItem)
   });

--- a/src/transfer/transfer.js
+++ b/src/transfer/transfer.js
@@ -7,7 +7,7 @@ const request = require('../request');
  * @param   {Object}  transfer A transfer object without items.
  * @returns {Promise} A transfer object
  */
-function create(transfer) {
+async function create(transfer) {
   return request.send(routes.transfers, normalizeTransfer(transfer));
 }
 


### PR DESCRIPTION
## Proposed changes

I'm running into a "The keyword 'await' is reserved error when I try to use the SDK. Per Stack Overflow we gotta have `async` before the function name for this to work. 

## Types of changes

What types of changes does your code introduce to wt-api-docs?
- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist
- [X] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [X] I have added necessary documentation (if appropriate)
- [X] Code changes are covered by unit tests.
- [X] Any dependent changes have been merged and published in downstream modules
