### PR TITLE
feat: upload files as buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,43 @@ const transfer = await apiClient.transfer.create({
 
 ### Transfer
 
-How to create a transfer, with no items yet:
+Transfers can be created with or without items. Once the transfer has been created, items can be added at any time:
 
 ```javascript
 const transfer = await apiClient.transfer.create({
   name: 'My very first transfer!',
-  description: ''
+  // Description is optional.
+  description: 'Something about cats, most probably.'
 });
+// transfer.shortened_url contains the public WeTransfer URL
 ```
 
-### Add some items
+### Add items to a transfer
 
-Items can be added to a transfer at any time:
+Once a transfer has been created you can then add items to it. If files are provided as items, they are not uploaded at this point, but `filesize` and `filename` must be provided at this point:
 
 ```javascript
-const items = await apiClient.transfer.addItems(transfer.id, [{
+const transferItems = await apiClient.transfer.addItems(transfer.id, [{
   content_identifier: 'file',
-  local_identifier: '',
-  filename: '',
-  filesize: '',
-  path: path.join(__dirname, './path/to/my-file.jpg'),
+  local_identifier: 'delightful-cat',
+  filename: 'kittie.gif',
+  filesize: 1024
 }]);
+```
+
+It will return an object for each file you want to add to the transfer. Each file must be split into chunks, and uploaded to a pre-signed S3 URL, provided by the following method.
+
+### Upload a file
+
+Once the item has been added to the transfer, next step is to upload the file or files. You must provide the content of the file to upload as a [Buffer](https://nodejs.org/api/buffer.html#buffer_class_buffer).
+
+```javascript
+// Depending on your application, you will read the file using fs.readFile
+// or it will be a file uploaded to your service.
+const fileContent = [/* Buffer */];
+await Promise.all(transferItems.map((item) => {
+  return apiClient.transfer.uploadFile(item, fileContent);
+}));
 ```
 
 ## Documentation

--- a/__tests__/transfer/items.js
+++ b/__tests__/transfer/items.js
@@ -17,7 +17,11 @@ describe('Transfer module', () => {
       });
 
       it('should return more than one chunk , if bigger than 5MB', () => {
-        expect(transferItems.getChunkSizes(5243904)).toEqual([0, 5242880, 1024]);
+        expect(transferItems.getChunkSizes(5243904)).toEqual([
+          0,
+          5242880,
+          1024
+        ]);
       });
     });
 
@@ -30,11 +34,23 @@ describe('Transfer module', () => {
       });
 
       it('should extract first chunk', () => {
-        expect(transferItems.extractDataChunk(data, chunkSizes, 2, 1)).toEqual(['00', '01', '02', '03', '04']);
+        expect(transferItems.extractDataChunk(data, chunkSizes, 2, 1)).toEqual([
+          '00',
+          '01',
+          '02',
+          '03',
+          '04'
+        ]);
       });
 
       it('should extract last chunk', () => {
-        expect(transferItems.extractDataChunk(data, chunkSizes, 2, 2)).toEqual(['05', '06', '07', '08', '09']);
+        expect(transferItems.extractDataChunk(data, chunkSizes, 2, 2)).toEqual([
+          '05',
+          '06',
+          '07',
+          '08',
+          '09'
+        ]);
       });
     });
 
@@ -48,26 +64,28 @@ describe('Transfer module', () => {
         request.apiKey = 'secret-api-key';
         request.jwt = 'json-web-token';
 
-        items = [{
-          filename: 'item-01.txt',
-          filesize: 1024,
-          content_identifier: 'file',
-          local_identifier: 'item-01.txt'
-        }];
+        items = [
+          {
+            filename: 'item-01.txt',
+            filesize: 1024,
+            content_identifier: 'file',
+            local_identifier: 'item-01.txt'
+          }
+        ];
 
-        createdItems = [{
-          'id': 'random-hash',
-          'content_identifier': 'file',
-          'local_identifier': 'item-01.txt',
-          'meta': {
-            'multipart_parts': 2,
-            'multipart_upload_id': 'some.random-id--'
-          },
-          'name': 'item-01.txt',
-          'size': 195906,
-          'upload_id': 'more.random-ids--',
-          'upload_expires_at': 1520410633
-        }];
+        createdItems = [
+          {
+            id: 'random-hash',
+            content_identifier: 'file',
+            local_identifier: 'item-01.txt',
+            meta: {
+              multipart_parts: 2,
+              multipart_upload_id: 'some.random-id--'
+            },
+            name: 'item-01.txt',
+            size: 195906
+          }
+        ];
 
         // TODO: move all these to an integration test?
         // nock('https://dev.wetransfer.com')
@@ -109,20 +127,22 @@ describe('Transfer module', () => {
         axios.mockImplementation(() => Promise.resolve({ data: createdItems }));
         await transferItems.addItems('transfer-id', items);
         expect(axios).toHaveBeenLastCalledWith({
-          'data': {
-            'items': [{
-              'content_identifier': 'file',
-              'filename': 'item-01.txt',
-              'filesize': 1024,
-              'local_identifier': 'item-01.txt'
-            }]
+          data: {
+            items: [
+              {
+                content_identifier: 'file',
+                filename: 'item-01.txt',
+                filesize: 1024,
+                local_identifier: 'item-01.txt'
+              }
+            ]
           },
-          'headers': {
+          headers: {
             'Authorization': 'Bearer json-web-token',
             'Content-Type': 'application/json',
             'x-api-key': 'secret-api-key'
           },
-          'url': '/v1/transfers/transfer-id/items'
+          url: '/v1/transfers/transfer-id/items'
         });
       });
 

--- a/example/create-transfer.js
+++ b/example/create-transfer.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+const createWTClient = require('../src');
+
+function readFile(path) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(path, (error, data) => {
+      if (error) {
+        return reject(error);
+      }
+
+      resolve(data);
+    });
+  });
+}
+
+(async function createTransfer() {
+  const data = {
+    transfer: {
+      name: 'WeTransfer SDK'
+    },
+    items: [
+      {
+        local_identifier: 'WeTransfer-01.jpg',
+        content_identifier: 'file',
+        filename: 'WeTransfer-01.jpg',
+        path: path.join(__dirname, './files/WeTransfer-01.jpg')
+      },
+      {
+        local_identifier: 'WeTransfer-02.jpg',
+        content_identifier: 'file',
+        filename: 'WeTransfer-02.jpg',
+        path: path.join(__dirname, './files/WeTransfer-02.jpg')
+      },
+      {
+        local_identifier: 'WeTransfer-03.jpg',
+        content_identifier: 'file',
+        filename: 'WeTransfer-03.jpg',
+        path: path.join(__dirname, './files/WeTransfer-03.jpg')
+      },
+      {
+        local_identifier: 'WeTransfer-04.jpg',
+        content_identifier: 'file',
+        filename: 'WeTransfer-04.jpg',
+        path: path.join(__dirname, './files/WeTransfer-04.jpg')
+      },
+      {
+        local_identifier: 'WeTransfer-05.jpg',
+        content_identifier: 'file',
+        filename: 'WeTransfer-05.jpg',
+        path: path.join(__dirname, './files/WeTransfer-05.jpg')
+      }
+    ]
+  };
+
+  const files = await Promise.all(
+    data.items.map((item) => {
+      return readFile(item.path);
+    })
+  );
+
+  try {
+    const apiClient = await createWTClient(
+      '/* Your private API KEY goes here */'
+    );
+
+    const transfer = await apiClient.transfer.create(data.transfer);
+    const transferItems = await apiClient.transfer.addItems(
+      transfer.id,
+      data.items.map((item, index) => {
+        item.filesize = files[index].length;
+        return item;
+      })
+    );
+    await Promise.all(
+      transferItems.map((item, index) => {
+        return apiClient.transfer.uploadFile(item, files[index]);
+      })
+    );
+
+    console.log(transfer.shortened_url);
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/src/transfer/items.js
+++ b/src/transfer/items.js
@@ -1,6 +1,4 @@
-const fs = require('fs');
-
-const { normalizeItem } = require('./model');
+const { normalizeItem, normalizeResponseItem } = require('./model');
 const routes = require('../config/routes');
 const request = require('../request');
 
@@ -65,9 +63,11 @@ function getChunkSizes(totalSize) {
  * @returns {Promise}            A collection of created items
  */
 function addItems(transferId, items) {
-  return request.send(routes.items(transferId), {
-    items: items.map(normalizeItem)
-  });
+  return request
+    .send(routes.items(transferId), {
+      items: items.map(normalizeItem)
+    })
+    .then((items) => items.map(normalizeResponseItem));
 }
 
 /**
@@ -97,43 +97,25 @@ function uploadPart(file, data, chunkSizes, partNumber) {
 /**
  * Given a file content, and the number of parts that must be uploaded to S3,
  * it chunkes the file and uploads each part in parallel
- * @param   {Object}  file Item containing information about number of parts, upload url, etc.
- * @param   {Buffer}  data File content
- * @returns {Promise}      Empty response if everything goes well 🤔
+ * TODO: accept blob as file content as well
+ * @param   {Object}  file    Item containing information about number of parts, upload url, etc.
+ * @param   {Buffer}  content File content
+ * @returns {Promise}         Empty response if everything goes well 🤔
  */
-function uploadFileParts(file, data) {
+function uploadFile(file, content) {
   const partRequests = [];
-  const chunkSizes = getChunkSizes(data.length, file.meta.multipart_parts);
+  const chunkSizes = getChunkSizes(content.length, file.meta.multipart_parts);
 
   for (
     let partNumber = 1;
     partNumber <= file.meta.multipart_parts;
     partNumber++
   ) {
-    partRequests.push(uploadPart(file, data, chunkSizes, partNumber));
+    // file.filesize = content.length;
+    partRequests.push(uploadPart(file, content, chunkSizes, partNumber));
   }
 
   return Promise.all(partRequests).then(() => completeFileUpload(file));
-}
-
-/**
- * Uploads a file given an absolute path.
- * TODO: accept a data buffer as well
- * @param   {Object}  file An item that represents a file.
- * @returns {Promise}      Empty response if everything goes well 🤔
- */
-function uploadFile(file) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(file.path, (error, data) => {
-      if (error) {
-        return reject(error);
-      }
-
-      uploadFileParts(file, data)
-        .then(resolve)
-        .catch(reject);
-    });
-  });
 }
 
 module.exports = {

--- a/src/transfer/items.js
+++ b/src/transfer/items.js
@@ -111,7 +111,6 @@ function uploadFile(file, content) {
     partNumber <= file.meta.multipart_parts;
     partNumber++
   ) {
-    // file.filesize = content.length;
     partRequests.push(uploadPart(file, content, chunkSizes, partNumber));
   }
 

--- a/src/transfer/model/index.js
+++ b/src/transfer/model/index.js
@@ -34,14 +34,37 @@ function normalizeTransfer(transfer) {
  */
 function normalizeItem(item) {
   // TODO: create different models for files and links
-  return defaults(
+  const normalizedItem = defaults(
     {},
     pick(item, Object.keys(defaultFileItem)),
     defaultFileItem
+  );
+
+  normalizedItem.filesize = parseInt(normalizedItem.filesize, 10);
+
+  return normalizedItem;
+}
+
+/**
+ * Normalizes a file response object. Removes non-expected properties and
+ * assigns a default value if key is not defined.
+ * @param {Object} item An item object. Can be a file or a link
+ * @returns {Object} Normalized response item object
+ */
+function normalizeResponseItem(item) {
+  return pick(
+    item,
+    'id',
+    'content_identifier',
+    'local_identifier',
+    'meta',
+    'name',
+    'size'
   );
 }
 
 module.exports = {
   normalizeTransfer,
-  normalizeItem
+  normalizeItem,
+  normalizeResponseItem
 };


### PR DESCRIPTION
## Proposed changes

This change removes the option of uploading a file given a path, and expects a `Buffer` as a content to be added to the transfer. Also adds some more documentation and a complete example on how to create a transfer and upload some files.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules
