### PR TITLE
fix: remove JSON circular dependencies

### DIFF
--- a/__tests__/items/actions/__snapshots__/add-files.js.snap
+++ b/__tests__/items/actions/__snapshots__/add-files.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Add files action should create an add items request 1`] = `
 Array [
-  RemoteFile {
+  Object {
     "content_identifier": "file",
     "id": "random-hash",
     "local_identifier": "delightful-cat",
@@ -12,11 +12,6 @@ Array [
     },
     "name": "kittie.gif",
     "size": 195906,
-    "transfer": RemoteTransfer {
-      "items": Array [
-        [Circular],
-      ],
-    },
   },
 ]
 `;

--- a/__tests__/items/actions/__snapshots__/add-items.js.snap
+++ b/__tests__/items/actions/__snapshots__/add-items.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Add items action should create an add items request 1`] = `
 Array [
-  RemoteFile {
+  Object {
     "content_identifier": "file",
     "id": "random-hash",
     "local_identifier": "delightful-cat",
@@ -13,7 +13,7 @@ Array [
     "name": "kittie.gif",
     "size": 195906,
   },
-  RemoteLink {
+  Object {
     "content_identifier": "web_content",
     "id": "random-hash",
     "meta": Object {

--- a/__tests__/items/actions/__snapshots__/add-links.js.snap
+++ b/__tests__/items/actions/__snapshots__/add-links.js.snap
@@ -2,16 +2,11 @@
 
 exports[`Add links action should create an add items request 1`] = `
 Array [
-  RemoteLink {
+  Object {
     "content_identifier": "web_content",
     "id": "random-hash",
     "meta": Object {
       "title": "WeTransfer",
-    },
-    "transfer": RemoteTransfer {
-      "items": Array [
-        [Circular],
-      ],
     },
   },
 ]

--- a/__tests__/items/models/__snapshots__/index.js.snap
+++ b/__tests__/items/models/__snapshots__/index.js.snap
@@ -32,7 +32,7 @@ Object {
 exports[`Item model normalizeItem function should throw an error if content_identifier is empty 1`] = `"Item's content_identifier property should be \\"file\\" or \\"web_content\\"."`;
 
 exports[`Item model normalizeResponseItem function should normalize a file item 1`] = `
-RemoteFile {
+Object {
   "content_identifier": "file",
   "id": "random-hash",
   "local_identifier": "delightful-cat",
@@ -46,7 +46,7 @@ RemoteFile {
 `;
 
 exports[`Item model normalizeResponseItem function should normalize a link item 1`] = `
-RemoteLink {
+Object {
   "content_identifier": "web_content",
   "id": "random-hash",
   "meta": Object {

--- a/__tests__/items/models/__snapshots__/remote-file.js.snap
+++ b/__tests__/items/models/__snapshots__/remote-file.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RemoteFile model contructor should create a normalized file 1`] = `
-RemoteFile {
+Object {
   "content_identifier": "file",
   "id": "random-hash",
   "local_identifier": "delightful-cat",

--- a/__tests__/items/models/__snapshots__/remote-link.js.snap
+++ b/__tests__/items/models/__snapshots__/remote-link.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RemoteLink model contructor should create a normalized link 1`] = `
-RemoteLink {
+Object {
   "content_identifier": "web_content",
   "id": "random-hash",
   "meta": Object {

--- a/src/items/models/remote-file.js
+++ b/src/items/models/remote-file.js
@@ -5,18 +5,23 @@ class RemoteFile {
     this.normalizeValues(values);
   }
 
+  fileProperties() {
+    return [
+      'id',
+      'content_identifier',
+      'local_identifier',
+      'meta',
+      'name',
+      'size'
+    ];
+  }
+
   normalizeValues(values) {
-    Object.assign(
-      this,
-      pick(values, [
-        'id',
-        'content_identifier',
-        'local_identifier',
-        'meta',
-        'name',
-        'size'
-      ])
-    );
+    Object.assign(this, pick(values, this.fileProperties()));
+  }
+
+  toJSON() {
+    return pick(this, this.fileProperties());
   }
 }
 

--- a/src/items/models/remote-link.js
+++ b/src/items/models/remote-link.js
@@ -5,11 +5,16 @@ class RemoteLink {
     this.normalizeValues(values);
   }
 
+  linkProperties() {
+    return ['id', 'content_identifier', 'meta', 'name'];
+  }
+
   normalizeValues(values) {
-    Object.assign(
-      this,
-      pick(values, ['id', 'content_identifier', 'meta', 'name'])
-    );
+    Object.assign(this, pick(values, this.linkProperties()));
+  }
+
+  toJSON() {
+    return pick(this, this.linkProperties());
   }
 }
 


### PR DESCRIPTION
## Proposed changes

There is an issue when trying to stringify Transfer and Items objects. A transfer object contains a list of items, and an items points to it's transfer, creating a circular dependency when trying to stringify the objects. This change filters the properties available when converting to JSON.

## Types of changes

- [ ] Docs (missing or updated docs)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

