### PR TITLE
chore: setup automatic release of CHANGELOG

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,6 @@
+{
+  "release": {
+    "verifyConditions": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
+    "prepare": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"]
+  }
+}


### PR DESCRIPTION
## Proposed changes

CHANGELOG automatic generation was not enabled within the semantic release process, and wasn't push to GH and included on the npm package.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [ ] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

