### PR TITLE
feat: add a logger mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ await Promise.all(
 );
 ```
 
+## Logging levels
+
+Logging levels in this SDK conform to the severity ordering specified by [RFC5424]: _severity of all levels is assumed to be numerically **ascending** from most important to least important._
+
+Each `level` is given a specific integer priority. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority.
+
+``` js
+{ 
+  error: 0, 
+  warn: 1, 
+  info: 2, 
+  verbose: 3, 
+  debug: 4, 
+  silly: 5 
+}
+```
+
+We make use of the `npm` levels showed above.
+
+Setting the level for your logging message can be done providing the value when creating WeTransfer. For example, using the `warn` level you could log `warn` messages and below to the console, which in this case will only be `warn` and `error`.
+
+```js
+const apiClient = await createWTClient('/* YOUR PRIVATE API KEY GOES HERE*/', {
+  logger: {
+    level: 'debug'
+  }
+});
+```
+
+If no value is provided, by default we will use `info`.
+
 ## Documentation
 
 Visit [https://developers.wetransfer.com/documentation](https://developers.wetransfer.com/documentation) to access the latest API related documentation.

--- a/__tests__/config/__snapshots__/logger.js.snap
+++ b/__tests__/config/__snapshots__/logger.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Logger configuration when setting a level that doesn't exist should keep default info level 1`] = `
+Array [
+  "[WeTransfer SDK] [33m\\"yolo\\" is not a valid logger level. Please specify one of the following levels: [[39m
+[33m      'error',[39m
+[33m      'warning',[39m
+[33m      'info',[39m
+[33m      'verbose,'[39m
+[33m      'debug',[39m
+[33m      'silly'[39m
+[33m    ][39m
+",
+]
+`;
+
+exports[`Logger configuration when setting an empty level should keep default info level 1`] = `undefined`;
+
+exports[`Logger configuration when silly level is set should log silly logs 1`] = `
+Array [
+  "[WeTransfer SDK] [35mThis is a silly log[39m
+",
+]
+`;

--- a/__tests__/config/logger.js
+++ b/__tests__/config/logger.js
@@ -1,0 +1,48 @@
+const logger = require('../../src/config/logger');
+
+describe('Logger configuration', () => {
+  let log;
+  beforeEach(() => {
+    logger.setLoggerLevel('info');
+    log = jest.spyOn(console._stdout, 'write').mockImplementation(() => {
+      /* don't console.log anything */
+    });
+  });
+
+  afterEach(() => {
+    log.mockRestore();
+  });
+
+  describe('when silly level is set', () => {
+    it('should log silly logs', () => {
+      logger.setLoggerLevel('silly');
+      logger.silly('This is a silly log');
+      expect(log.mock.calls[log.mock.calls.length - 1]).toMatchSnapshot();
+    });
+  });
+
+  describe('when error level is set', () => {
+    it('should NOT log silly logs', () => {
+      logger.setLoggerLevel('error');
+      logger.silly('This is a silly log');
+      expect(log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when setting a level that doesn\'t exist', () => {
+    it('should keep default info level', () => {
+      logger.setLoggerLevel('yolo');
+      expect(log.mock.calls[log.mock.calls.length - 1]).toMatchSnapshot();
+      expect(logger.transports[0].level).toBe('info');
+    });
+  });
+
+  describe('when setting an empty level', () => {
+    it('should keep default info level', () => {
+      expect(logger.transports[0].level).toBe('info');
+      logger.setLoggerLevel();
+      expect(log.mock.calls[log.mock.calls.length - 1]).toMatchSnapshot();
+      expect(logger.transports[0].level).toBe('info');
+    });
+  });
+});

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -10,7 +10,12 @@ describe('createWTClient function', () => {
   });
 
   it('should return a client if API KEY is provided', async () => {
-    const apiClient = await createWTClient('super-secret-api-key');
+    const apiClient = await createWTClient('super-secret-api-key', {
+      logger: {
+        level: 'error'
+      }
+    });
+
     expect(apiClient).toEqual({
       authorize: expect.any(Function),
       transfer: {

--- a/example/create-transfer.js
+++ b/example/create-transfer.js
@@ -62,7 +62,11 @@ const data = {
   );
 
   try {
-    const apiClient = await createWTClient(process.env.WT_API_KEY);
+    const apiClient = await createWTClient(process.env.WT_API_KEY, {
+      logger: {
+        level: 'silly'
+      }
+    });
 
     const transfer = await apiClient.transfer.create(data.transfer);
     const transferFiles = await apiClient.transfer.addFiles(

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "axios": "0.18.0",
-    "lodash": "4.17.10"
+    "lodash": "4.17.10",
+    "winston": "3.0.0"
   },
   "devDependencies": {
     "@wetransfer/eslint-config-wetransfer": "2.0.1",
@@ -51,6 +52,9 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "setupFiles": [
+      "./scripts/jest/setup.js"
+    ],
     "watchPlugins": [
       "jest-watch-typeahead/filename",
       "jest-watch-typeahead/testname"

--- a/scripts/jest/setup.js
+++ b/scripts/jest/setup.js
@@ -1,0 +1,3 @@
+const logger = require('../../src/config/logger');
+
+logger.setLoggerLevel('error');

--- a/src/authorize/authorize.js
+++ b/src/authorize/authorize.js
@@ -1,8 +1,10 @@
 const WTError = require('../error');
+const logger = require('../config/logger');
 
 module.exports = function({ request, routes }) {
   return async function authorize() {
     try {
+      logger.info('Authorizing your API key.');
       return await request.send(routes.authorize);
     } catch (error) {
       throw new WTError(

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -1,0 +1,45 @@
+const { includes } = require('lodash');
+const winston = require('winston');
+const { createLogger, config, format } = winston;
+const { colorize, combine, label, printf } = format;
+
+const customFormat = printf((info) => `[${info.label}] ${info.message}`);
+
+const transports = {
+  console: new winston.transports.Console({ level: 'info' })
+};
+
+const logger = createLogger({
+  levels: config.npm.levels,
+  format: combine(
+    colorize({ all: true }),
+    label({ label: 'WeTransfer SDK' }),
+    customFormat
+  ),
+  transports: [transports.console]
+});
+
+winston.addColors({
+  error: 'red',
+  warn: 'yellow',
+  info: 'white',
+  debug: 'white'
+});
+
+function setLoggerLevel(level = 'info') {
+  if (!includes(Object.keys(config.npm.levels), level)) {
+    return logger.warn(`"${level}" is not a valid logger level. Please specify one of the following levels: [
+      'error',
+      'warning',
+      'info',
+      'verbose,'
+      'debug',
+      'silly'
+    ]`);
+  }
+
+  transports.console.level = level;
+}
+
+module.exports = logger;
+module.exports.setLoggerLevel = setLoggerLevel;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
-const authorize = require('./authorize');
+const { get } = require('lodash');
+
 const WTError = require('./error');
+const logger = require('./config/logger');
+
+const authorize = require('./authorize');
 const request = require('./request');
 const { create } = require('./transfer');
 const {
@@ -10,10 +14,15 @@ const {
   completeFileUpload
 } = require('./items');
 
-module.exports = async function createWTClient(apiKey) {
+module.exports = async function createWTClient(
+  apiKey,
+  options = { logger: {} }
+) {
   if (!apiKey) {
     throw new WTError('No API Key provided');
   }
+
+  logger.setLoggerLevel(get(options, 'logger.level', 'info'));
 
   request.apiKey = apiKey;
   request.jwt = (await authorize()).token;

--- a/src/items/actions/add-files.js
+++ b/src/items/actions/add-files.js
@@ -1,3 +1,5 @@
+const logger = require('../../config/logger');
+
 module.exports = function({ sendItems, futureFile, RemoteFile }) {
   /**
    * Add files to an existing transfer.
@@ -6,6 +8,10 @@ module.exports = function({ sendItems, futureFile, RemoteFile }) {
    * @returns {Promise}          A collection of created items
    */
   return async function addFiles(transfer, files) {
+    logger.info(
+      `Adding ${files.length} files to transfer with ID ${transfer.id}`
+    );
+
     const transferItems = (await sendItems(
       transfer,
       files.map(futureFile)

--- a/src/items/actions/add-items.js
+++ b/src/items/actions/add-items.js
@@ -1,3 +1,5 @@
+const logger = require('../../config/logger');
+
 module.exports = function({ sendItems, normalizeItem, normalizeResponseItem }) {
   /**
    * Add items to an existing transfer.
@@ -6,8 +8,8 @@ module.exports = function({ sendItems, normalizeItem, normalizeResponseItem }) {
    * @returns {Promise}            A collection of created items
    */
   return async function addItems(transferId, items) {
-    console.warn(
-      '[DEPRECATED WARNING]: addItems method will be removed in future versions. Please use addFiles or addLinks methods instead.'
+    logger.warn(
+      '[DEPRECATED]: addItems method will be removed in future versions. Please use addFiles or addLinks methods instead.'
     );
     return (await sendItems({ id: transferId }, items.map(normalizeItem))).map(
       normalizeResponseItem

--- a/src/items/actions/add-links.js
+++ b/src/items/actions/add-links.js
@@ -1,3 +1,5 @@
+const logger = require('../../config/logger');
+
 module.exports = function({ sendItems, futureLink, RemoteLink }) {
   /**
    * Add links to an existing transfer.
@@ -6,6 +8,10 @@ module.exports = function({ sendItems, futureLink, RemoteLink }) {
    * @returns {Promise}          A collection of created items
    */
   return async function addLinks(transfer, links) {
+    logger.info(
+      `Adding ${links.length} links to transfer with ID ${transfer.id}`
+    );
+
     const transferItems = (await sendItems(
       transfer,
       links.map(futureLink)

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -1,6 +1,8 @@
 const axios = require('axios');
 const { merge } = require('lodash');
 
+const logger = require('../config/logger');
+
 axios.defaults.baseURL = 'https://dev.wetransfer.com/';
 axios.defaults.method = 'post';
 
@@ -32,6 +34,12 @@ function send(options = {}, data = null) {
     { data }
   );
 
+  const log = {
+    method: (options.method || axios.defaults.method).toUpperCase()
+  };
+  logger.debug(
+    `Network request ${log.method} ${options.url} ${JSON.stringify(data)}`
+  );
   return axios(requestOptions).then((response) => response.data);
 }
 
@@ -41,6 +49,8 @@ function upload(uploadUrl, data) {
     method: 'put',
     data
   };
+
+  logger.debug(`File upload request PUT ${uploadUrl}`);
   return axios(requestOptions).then((response) => response.data);
 }
 

--- a/src/transfer/actions/create.js
+++ b/src/transfer/actions/create.js
@@ -1,4 +1,5 @@
 const WTError = require('../../error');
+const logger = require('../../config/logger');
 const futureTransfer = require('../models/future-transfer');
 const RemoteTransfer = require('../models/remote-transfer');
 
@@ -10,10 +11,12 @@ module.exports = function({ request, routes }) {
    */
   return async function createTransfer(transfer) {
     try {
+      logger.info('Creating a new transfer.');
       const response = await request.send(
         routes.transfers,
         futureTransfer(transfer)
       );
+      logger.info(`Transfer created with id ${response.id}.`);
       return new RemoteTransfer(response);
     } catch (error) {
       throw new WTError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,6 +330,12 @@ async@^2.1.4:
   dependencies:
     lodash "^4.14.0"
 
+async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  dependencies:
+    lodash "^4.17.10"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -797,19 +803,51 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
+color-convert@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
-color-name@^1.1.1:
+color-name@^1.0.0, color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+color-string@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
+  dependencies:
+    color-name "^1.0.0"
+
+color@0.8.x:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-0.8.0.tgz#890c07c3fd4e649537638911cf691e5458b6fca5"
+  dependencies:
+    color-convert "^0.5.0"
+    color-string "^0.3.0"
+
+colornames@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/colornames/-/colornames-0.0.2.tgz#d811fd6c84f59029499a8ac4436202935b92be31"
 
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+
+colors@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.0.tgz#5f20c9fef6945cb1134260aab33bfbdc8295e04e"
+
+colorspace@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.0.1.tgz#c99c796ed31128b9876a52e1ee5ee03a4a719749"
+  dependencies:
+    color "0.8.x"
+    text-hex "0.0.x"
 
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -1080,6 +1118,14 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
+diagnostics@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.1.0.tgz#e1090900b49523e8527be20f081275205f2ae36a"
+  dependencies:
+    colorspace "1.0.x"
+    enabled "1.0.x"
+    kuler "0.0.x"
+
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -1121,12 +1167,22 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+enabled@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
+  dependencies:
+    env-variable "0.0.x"
+
 env-ci@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/env-ci/-/env-ci-2.1.0.tgz#615fc08b386c41f30c9ae567b6b30703e4ce9caa"
   dependencies:
     execa "^0.10.0"
     java-properties "^0.2.9"
+
+env-variable@0.0.x:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.4.tgz#0d6280cf507d84242befe35a512b5ae4be77c54e"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -1409,11 +1465,19 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-safe-stringify@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.4.tgz#4fe828718aa61dbcf9119c3c24e79cc4dea973b2"
+
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+fecha@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2686,6 +2750,12 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+kuler@0.0.x:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-0.0.0.tgz#b66bb46b934e550f59d818848e0abba4f7f5553c"
+  dependencies:
+    colornames "0.0.2"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -2756,13 +2826,23 @@ lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
 
-lodash@4.17.10:
+lodash@4.17.10, lodash@^4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lodash@4.17.5, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+logform@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-1.9.1.tgz#58b29d7b11c332456d7a217e17b48a13ad69d60a"
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^2.3.3"
+    ms "^2.1.1"
+    triple-beam "^1.2.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2941,6 +3021,10 @@ modify-values@^1.0.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -3133,6 +3217,10 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+one-time@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -3497,7 +3585,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -4001,6 +4089,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -4173,6 +4265,10 @@ text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
 
+text-hex@0.0.x:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-0.0.0.tgz#578fbc85a6a92636e42dd17b41d0218cce9eb2b3"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4255,6 +4351,10 @@ trim-off-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -4427,6 +4527,27 @@ wide-align@^1.1.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+winston-transport@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.2.0.tgz#a20be89edf2ea2ca39ba25f3e50344d73e6520e5"
+  dependencies:
+    readable-stream "^2.3.6"
+    triple-beam "^1.2.0"
+
+winston@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.0.0.tgz#1f0b24a96586798bcf0cd149fb07ed47cb01a1b2"
+  dependencies:
+    async "^2.6.0"
+    diagnostics "^1.0.1"
+    is-stream "^1.1.0"
+    logform "^1.9.0"
+    one-time "0.0.4"
+    readable-stream "^2.3.6"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.2.0"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
## Proposed changes

Add a logger mechanism (we use `winston` package in that case) to manage log and error messages in a better way than using just `console.log`. We also allow the user to set the level of verbosity, from `silly` to `error`.

Closes #4 

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules
