### PR TITLE
feat: add get upload URL method

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -25,6 +25,9 @@ describe('createWTClient function', () => {
         completeFileUpload: expect.any(Function),
         create: expect.any(Function),
         uploadFile: expect.any(Function)
+      },
+      file: {
+        getUploadURL: expect.any(Function)
       }
     });
   });

--- a/__tests__/items/actions/get-upload-url.js
+++ b/__tests__/items/actions/get-upload-url.js
@@ -1,0 +1,34 @@
+const routes = require('../../../src/config/routes');
+const getUploadUrlAction = require('../../../src/items/actions/get-upload-url');
+
+describe('Get upload URL action', () => {
+  let getUploadUrl = null;
+  const mocks = {};
+  beforeEach(() => {
+    mocks.request = { send: jest.fn() };
+    mocks.request.send.mockReturnValue(() =>
+      Promise.resolve({ upload_url: 's3://very-long-url' })
+    );
+
+    getUploadUrl = getUploadUrlAction({
+      routes,
+      request: mocks.request
+    });
+  });
+
+  it('should send a request to retrieve the url', async () => {
+    await getUploadUrl(
+      {
+        id: 'file-id',
+        meta: {
+          multipart_upload_id: 'multipart-upload-id'
+        }
+      },
+      1
+    );
+    expect(mocks.request.send).toHaveBeenCalledWith({
+      method: 'get',
+      url: '/v1/files/file-id/uploads/1/multipart-upload-id'
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ const {
   addFiles,
   addLinks,
   uploadFile,
-  completeFileUpload
+  completeFileUpload,
+  getUploadURL
 } = require('./items');
 
 module.exports = async function createWTClient(
@@ -36,6 +37,9 @@ module.exports = async function createWTClient(
       addLinks,
       uploadFile,
       completeFileUpload
+    },
+    file: {
+      getUploadURL
     }
   };
 };

--- a/src/items/actions/get-upload-url.js
+++ b/src/items/actions/get-upload-url.js
@@ -1,0 +1,17 @@
+const logger = require('../../config/logger');
+
+module.exports = function({ request, routes }) {
+  /**
+   * Get an upload URL for an specific file part
+   * @param   {Object}  file       Item containing information about number of parts, upload url, etc.
+   * @param   {Number}  partNumber A collection of items to be added to the transfer
+   * @returns {Promise}            A collection of created items
+   */
+  return async function getUploadURL(file, partNumber) {
+    logger.info(
+      `Requesting S3 upload URL for part #${partNumber} of file ${file.id}`
+    );
+
+    return request.send(routes.multipart(file, partNumber));
+  };
+};

--- a/src/items/actions/get-upload-url.js
+++ b/src/items/actions/get-upload-url.js
@@ -4,8 +4,8 @@ module.exports = function({ request, routes }) {
   /**
    * Get an upload URL for an specific file part
    * @param   {Object}  file       Item containing information about number of parts, upload url, etc.
-   * @param   {Number}  partNumber A collection of items to be added to the transfer
-   * @returns {Promise}            A collection of created items
+   * @param   {Number}  partNumber Which part number to upload
+   * @returns {Promise}            An object containing the upload url, expiring date, etc
    */
   return async function getUploadURL(file, partNumber) {
     logger.info(

--- a/src/items/actions/index.js
+++ b/src/items/actions/index.js
@@ -21,5 +21,6 @@ module.exports = {
   addFiles: require('./add-files')({ sendItems, futureFile, RemoteFile }),
   addLinks: require('./add-links')({ sendItems, futureLink, RemoteLink }),
   uploadFile: require('./upload-file')({ request, routes }),
-  completeFileUpload: require('./complete-file-upload')({ request, routes })
+  completeFileUpload: require('./complete-file-upload')({ request, routes }),
+  getUploadURL: require('./get-upload-url')({ request, routes })
 };

--- a/src/items/actions/upload-file.js
+++ b/src/items/actions/upload-file.js
@@ -2,6 +2,7 @@ const logger = require('../../config/logger');
 const WTError = require('../../error');
 
 module.exports = function({ request, routes }) {
+  const getUploadUrl = require('./get-upload-url')({ request, routes });
   const completeFileUpload = require('./complete-file-upload')({
     request,
     routes
@@ -21,16 +22,14 @@ module.exports = function({ request, routes }) {
     logger.debug(
       `[${file.name}] Requesting S3 upload URL for part #${partNumber}`
     );
-    return request
-      .send(routes.multipart(file, partNumber))
-      .then((multipartItem) => {
-        logger.debug(
-          `[${file.name}] Uploading ${
-            data.length
-          } bytes for part #${partNumber} to S3`
-        );
-        return request.upload(multipartItem.upload_url, data);
-      });
+    return getUploadUrl(file, partNumber).then((multipartItem) => {
+      logger.debug(
+        `[${file.name}] Uploading ${
+          data.length
+        } bytes for part #${partNumber} to S3`
+      );
+      return request.upload(multipartItem.upload_url, data);
+    });
   }
 
   /**

--- a/src/items/index.js
+++ b/src/items/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   addItems,
   uploadFile,
-  completeFileUpload
+  completeFileUpload,
+  getUploadURL
 } = require('./actions');


### PR DESCRIPTION
## Proposed changes

Add `apiClient.file.getUploadUrl` method to allow file uploads directly from the clients.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

