### PR TITLE
feat: add expires_at property to remote transfer

### DIFF
--- a/__tests__/actions/__snapshots__/find.js.snap
+++ b/__tests__/actions/__snapshots__/find.js.snap
@@ -13,6 +13,7 @@ RemoteBoard {
 
 exports[`Find action when finding a transfer should return a RemoteTransfer object 1`] = `
 RemoteTransfer {
+  "expires_at": 2018-01-01T00:00:00.000Z,
   "files": Array [],
   "id": "transfer-id",
   "message": "Little kittens",

--- a/__tests__/actions/find.js
+++ b/__tests__/actions/find.js
@@ -63,6 +63,7 @@ describe('Find action', () => {
         state: 'uploading',
         url: 'https://we.tl/s-random-hash',
         files: [],
+        expires_at: '2018-01-01T00:00:00Z',
       });
 
       find = findAction({

--- a/__tests__/transfers/actions/__snapshots__/create.js.snap
+++ b/__tests__/transfers/actions/__snapshots__/create.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Create transfer action should create a finalize transfer request if content is provided 1`] = `
 Object {
+  "expires_at": Object {},
   "files": Array [
     Object {
       "id": "random-hash",
@@ -17,7 +18,8 @@ Object {
 `;
 
 exports[`Create transfer action should create an upload file request if content is provided 1`] = `
-Object {
+RemoteTransfer {
+  "expires_at": 2018-01-01T00:00:00.000Z,
   "files": Array [
     Object {
       "id": "random-hash",
@@ -34,6 +36,7 @@ Object {
 
 exports[`Create transfer action should return a RemoteTransfer object 1`] = `
 RemoteTransfer {
+  "expires_at": 2018-01-01T00:00:00.000Z,
   "files": Array [
     Object {
       "id": "random-hash",

--- a/__tests__/transfers/actions/__snapshots__/finalize.js.snap
+++ b/__tests__/transfers/actions/__snapshots__/finalize.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Finalize transfer action should create a finalize transfer request 1`] = `
 RemoteTransfer {
+  "expires_at": 2018-01-01T00:00:00.000Z,
   "files": Array [
     Object {
       "id": "random-hash",

--- a/__tests__/transfers/actions/create.js
+++ b/__tests__/transfers/actions/create.js
@@ -8,8 +8,9 @@ describe('Create transfer action', () => {
   beforeEach(() => {
     mocks.request = { send: jest.fn() };
     mocks.uploadFileToTransfer = jest.fn();
-    mocks.finalizeTransfer = jest.fn();
-    mocks.finalizeTransfer = mocks.request.send.mockReturnValue({
+    mocks.finalizeTransfer = jest.fn((transfer) => transfer);
+
+    mocks.request.send.mockReturnValue({
       id: 'random-hash',
       message: 'Little kittens',
       state: 'uploading',
@@ -21,6 +22,7 @@ describe('Create transfer action', () => {
           type: 'file',
         },
       ],
+      expires_at: '2018-01-01T00:00:00Z',
     });
 
     create = createAction({

--- a/__tests__/transfers/actions/finalize.js
+++ b/__tests__/transfers/actions/finalize.js
@@ -20,6 +20,7 @@ describe('Finalize transfer action', () => {
           type: 'file',
         },
       ],
+      expires_at: '2018-01-01T00:00:00Z',
     });
 
     finalize = finalizeAction({

--- a/__tests__/transfers/models/__snapshots__/remote-transfer.js.snap
+++ b/__tests__/transfers/models/__snapshots__/remote-transfer.js.snap
@@ -2,6 +2,7 @@
 
 exports[`RemoteTransfer model contructor should create a normalized transfer 1`] = `
 RemoteTransfer {
+  "expires_at": 2018-01-01T00:00:00.000Z,
   "files": Array [
     Object {
       "id": "random-hash",

--- a/__tests__/transfers/models/remote-transfer.js
+++ b/__tests__/transfers/models/remote-transfer.js
@@ -15,6 +15,7 @@ describe('RemoteTransfer model', () => {
           type: 'file',
         },
       ],
+      expires_at: '2018-01-01T00:00:00Z',
     });
   });
 

--- a/src/transfers/actions/create.js
+++ b/src/transfers/actions/create.js
@@ -59,17 +59,14 @@ module.exports = function({
       );
       logger.info(`Transfer created with id ${response.id}.`);
 
-      let remoteTransfer = new RemoteTransfer(response);
+      const remoteTransfer = new RemoteTransfer(response);
 
       // If the files array contains the content of the file
       // lets upload directly, without asking the user to do it,
       // and finalize the transfer in one go.
       if (shouldUploadFiles(transfer.files)) {
         const filesContent = contentForFiles(transfer.files);
-        remoteTransfer = await uploadFilesAndFinalize(
-          filesContent,
-          remoteTransfer
-        );
+        return await uploadFilesAndFinalize(filesContent, remoteTransfer);
       }
 
       return remoteTransfer;

--- a/src/transfers/models/remote-transfer.js
+++ b/src/transfers/models/remote-transfer.js
@@ -1,6 +1,8 @@
 class RemoteTransfer {
   constructor(values) {
     Object.assign(this, values);
+
+    this.expires_at = new Date(this.expires_at);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

The API not returns an extra property called `expires_at` for remote transfers. This change transforms the value into a `Date` object.

Closes https://github.com/WeTransfer/wt-js-sdk/issues/160

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules

