### PR TITLE
feat: concurrent file uploads

### DIFF
--- a/__tests__/boards/actions/__snapshots__/add-files.js.snap
+++ b/__tests__/boards/actions/__snapshots__/add-files.js.snap
@@ -31,5 +31,3 @@ Array [
   },
 ]
 `;
-
-exports[`Add files action should throw an error if arguments are not provided 1`] = `[Error: There was an error when adding files to the board.]`;

--- a/__tests__/boards/actions/add-files.js
+++ b/__tests__/boards/actions/add-files.js
@@ -10,7 +10,7 @@ describe('Add files action', () => {
   const mocks = {};
   beforeEach(() => {
     mocks.request = { send: jest.fn() };
-    mocks.uploadFileToBoard = jest.fn();
+    mocks.enqueueFileTask = jest.fn(() => Promise.resolve());
     mocks.request.send.mockReturnValue([
       createRemoteMockFile({
         size: 195906,
@@ -25,7 +25,7 @@ describe('Add files action', () => {
     addFiles = addFilesAction({
       routes,
       request: mocks.request,
-      uploadFileToBoard: mocks.uploadFileToBoard,
+      enqueueFileTask: mocks.enqueueFileTask,
     });
 
     board = new RemoteBoard({
@@ -42,9 +42,9 @@ describe('Add files action', () => {
   it('should create an upload file request', async () => {
     const files = await addFiles(board, [createLocalMockFile({ content: [] })]);
     expect(files).toMatchSnapshot();
-    expect(mocks.uploadFileToBoard).toHaveBeenCalledWith(
-      board,
-      {
+    expect(mocks.enqueueFileTask).toHaveBeenCalledWith({
+      transferOrBoard: board,
+      file: {
         id: 'random-hash',
         multipart: { chunk_size: 195906, id: 'multipart-id', part_numbers: 3 },
         name: 'kittie.gif',
@@ -52,8 +52,8 @@ describe('Add files action', () => {
         type: 'file',
         chunks: [],
       },
-      []
-    );
+      content: [],
+    });
   });
 
   it('should throw an error if arguments are not provided', async () => {

--- a/__tests__/boards/actions/add-files.js
+++ b/__tests__/boards/actions/add-files.js
@@ -60,27 +60,20 @@ describe('Add files action', () => {
   });
 
   it('should throw an error if request fails', async () => {
-    try {
-      mocks.uploadFile.mockImplementation(() =>
-        Promise.reject(new Error('Network error.'))
-      );
-      await addFiles(board, [createLocalMockFile({ content: [] })]);
-    } catch (error) {
-      expect(error.message).toBe(
-        'There was an error when adding files to the board.'
-      );
-    }
+    mocks.uploadFile.mockImplementation(() =>
+      Promise.reject(new Error('Network error.'))
+    );
+    await expect(
+      addFiles(board, [createLocalMockFile({ content: [] })])
+    ).rejects.toThrow('There was an error when adding files to the board.');
   });
 
   it('should throw an error if arguments are not provided', async () => {
     mocks.request.send.mockReturnValue(() =>
       Promise.reject(new Error('Network error.'))
     );
-
-    try {
-      await addFiles();
-    } catch (error) {
-      expect(error).toMatchSnapshot();
-    }
+    await expect(addFiles()).rejects.toThrow(
+      'There was an error when adding files to the board.'
+    );
   });
 });

--- a/__tests__/transfers/actions/create.js
+++ b/__tests__/transfers/actions/create.js
@@ -10,7 +10,7 @@ describe('Create transfer action', () => {
   const mocks = {};
   beforeEach(() => {
     mocks.request = { send: jest.fn() };
-    mocks.uploadFileToTransfer = jest.fn();
+    mocks.enqueueFileTask = jest.fn(() => Promise.resolve());
     mocks.finalizeTransfer = jest.fn((transfer) => transfer);
 
     mocks.request.send.mockReturnValue({
@@ -24,7 +24,7 @@ describe('Create transfer action', () => {
     create = createAction({
       routes,
       request: mocks.request,
-      uploadFileToTransfer: mocks.uploadFileToTransfer,
+      enqueueFileTask: mocks.enqueueFileTask,
       finalizeTransfer: mocks.finalizeTransfer,
     });
   });
@@ -59,9 +59,9 @@ describe('Create transfer action', () => {
       files: [createLocalMockFile({ content: [] })],
     });
     expect(transfer).toMatchSnapshot();
-    expect(mocks.uploadFileToTransfer).toHaveBeenCalledWith(
-      transfer,
-      {
+    expect(mocks.enqueueFileTask).toHaveBeenCalledWith({
+      transferOrBoard: transfer,
+      file: {
         id: 'random-hash',
         name: 'kittie.gif',
         size: 1024,
@@ -69,8 +69,8 @@ describe('Create transfer action', () => {
         multipart: { chunk_size: 1024, id: 'multipart-id', part_numbers: 1 },
         chunks: [],
       },
-      []
-    );
+      content: [],
+    });
   });
 
   it('should create a finalize transfer request if content is provided', async () => {

--- a/src/actions/queues/files-queue.js
+++ b/src/actions/queues/files-queue.js
@@ -1,0 +1,35 @@
+const queue = require('async/queue');
+
+const config = require('../../config');
+const logger = require('../../config/logger');
+
+module.exports = function({ uploadFile }) {
+  // Expand the data from the task to perform a file upload
+  async function processFileTask(task) {
+    await uploadFile(task.transferOrBoard, task.file, task.content);
+  }
+
+  // Create a queue object with a concurrency defined in the configuration.
+  // processFileTask will be executed for every task.
+  const uploadQueue = queue(processFileTask, config.concurrency);
+
+  return function enqueueFileTask(task) {
+    return new Promise((resolve, reject) => {
+      const fileName = task.file.name;
+
+      logger.debug(`[${fileName}] Queuing file to be uploaded.`);
+
+      uploadQueue.push(task, (error) => {
+        if (error) {
+          logger.debug(`[${fileName}] Queue: file failed to upload.`);
+
+          return reject(error);
+        }
+
+        logger.debug(`[${fileName}] Queue: file upload complete.`);
+
+        resolve(task);
+      });
+    });
+  };
+};

--- a/src/boards/actions/add-files.js
+++ b/src/boards/actions/add-files.js
@@ -60,7 +60,6 @@ module.exports = function({ request, routes, enqueueFileTask }) {
 
       return boardFiles;
     } catch (error) {
-      console.error(error);
       throw new WTError(
         'There was an error when adding files to the board.',
         error

--- a/src/boards/actions/add-files.js
+++ b/src/boards/actions/add-files.js
@@ -4,7 +4,7 @@ const futureFile = require('../models/future-file');
 const { RemoteFile } = require('../../models');
 const contentForFiles = require('../../utils/content-for-files');
 
-module.exports = function({ request, routes, uploadFileToBoard }) {
+module.exports = function({ request, routes, enqueueFileTask }) {
   /**
    * Check if the user also passed the content for files.
    * In that case, we can upload the files in one go.
@@ -15,6 +15,24 @@ module.exports = function({ request, routes, uploadFileToBoard }) {
     return files.reduce(
       (uploadFiles, file) => uploadFiles && Boolean(file.content),
       true
+    );
+  }
+
+  /**
+   * Given the content of the files and a remote board, upload all the files.
+   * @param   {Array}   filesContent An array containing the content of each file
+   * @param   {Object}  remoteBoard  A board object
+   * @returns {Promise}
+   */
+  function uploadFiles(files, filesContent, remoteBoard) {
+    return Promise.all(
+      files.map((file) =>
+        enqueueFileTask({
+          transferOrBoard: remoteBoard,
+          file: file,
+          content: filesContent[file.name],
+        })
+      )
     );
   }
 
@@ -37,15 +55,12 @@ module.exports = function({ request, routes, uploadFileToBoard }) {
 
       if (shouldUploadFiles(files)) {
         const filesContent = contentForFiles(files);
-        await Promise.all(
-          boardFiles.map((file) => {
-            return uploadFileToBoard(board, file, filesContent[file.name]);
-          })
-        );
+        await uploadFiles(boardFiles, filesContent, board);
       }
 
       return boardFiles;
     } catch (error) {
+      console.error(error);
       throw new WTError(
         'There was an error when adding files to the board.',
         error

--- a/src/boards/actions/index.js
+++ b/src/boards/actions/index.js
@@ -27,10 +27,13 @@ const uploadFileToBoard = require('../../actions/upload-file')({
   enqueueChunk,
   completeFileUpload,
 });
+const enqueueFileTask = require('../../actions/queues/files-queue')({
+  uploadFile: uploadFileToBoard,
+});
 const addFilesToBoard = require('./add-files')({
   request,
   routes,
-  uploadFileToBoard,
+  enqueueFileTask,
 });
 const addLinksToBoard = require('./add-links')({ request, routes });
 

--- a/src/transfers/actions/create.js
+++ b/src/transfers/actions/create.js
@@ -7,7 +7,7 @@ const { futureTransfer, RemoteTransfer } = require('../models');
 module.exports = function({
   request,
   routes,
-  uploadFileToTransfer,
+  enqueueFileTask,
   finalizeTransfer,
 }) {
   /**
@@ -32,13 +32,13 @@ module.exports = function({
    */
   async function uploadFilesAndFinalize(filesContent, remoteTransfer) {
     await Promise.all(
-      remoteTransfer.files.map((file) => {
-        return uploadFileToTransfer(
-          remoteTransfer,
-          file,
-          filesContent[file.name]
-        );
-      })
+      remoteTransfer.files.map((file) =>
+        enqueueFileTask({
+          transferOrBoard: remoteTransfer,
+          file: file,
+          content: filesContent[file.name],
+        })
+      )
     );
 
     return await finalizeTransfer(remoteTransfer);

--- a/src/transfers/actions/index.js
+++ b/src/transfers/actions/index.js
@@ -21,11 +21,14 @@ const uploadFileToTransfer = require('../../actions/upload-file')({
   enqueueChunk,
   completeFileUpload,
 });
+const enqueueFileTask = require('../../actions/queues/files-queue')({
+  uploadFile: uploadFileToTransfer,
+});
 const finalizeTransfer = require('./finalize')({ request, routes });
 const createTransfer = require('./create')({
   request,
   routes,
-  uploadFileToTransfer,
+  enqueueFileTask,
   finalizeTransfer,
 });
 const findTransfer = require('../../actions/find')({


### PR DESCRIPTION
## Proposed changes

In continuation for https://github.com/WeTransfer/wt-js-sdk/pull/202, this PR enables concurrent file uploads.

The current implementation upload files one by one, which doesn't perform really well for fies smaller than 5MB. With that change, files can be uploaded in parallel, allowing faster upload speeds.

## Types of changes

- [ ] Docs (missing or updated docs)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement / maintenance (removing technical debt, performance, tooling, etc...)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/WeTransfer/wt-api-docs/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if appropriate)
- [x] Code changes are covered by unit tests.
- [ ] Any dependent changes have been merged and published in downstream modules
